### PR TITLE
Fix detection of updated wp-plugin packages

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths:
       - 'composer.lock'
-      - 'composer.json'
 
 jobs:
   changelog:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Comment changelogs on PR

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Follow Roots](https://img.shields.io/badge/follow%20@rootswp-1da1f2?logo=twitter&logoColor=ffffff&message=&style=flat-square)](https://twitter.com/rootswp)
 [![Sponsor Roots](https://img.shields.io/badge/sponsor%20roots-525ddc?logo=github&style=flat-square&logoColor=ffffff&message=)](https://github.com/sponsors/roots)
 
-Automatically comment WordPress plugin changelogs on pull requests when [WP Packages](https://wp-packages.org/) dependencies change in your `composer.lock` or `composer.json` files.
+Automatically comment WordPress plugin changelogs on pull requests when [WP Packages](https://wp-packages.org/) dependencies change in your `composer.lock`.
 
 ## Support us
 
@@ -11,7 +11,7 @@ We're dedicated to pushing modern WordPress development forward through our open
 
 ## Features
 
-- Detects changes to [WP Packages](https://wp-packages.org/) plugins in both `composer.lock` and `composer.json`
+- Detects changes to [WP Packages](https://wp-packages.org/) plugins in `composer.lock`
 - Fetches changelogs from WordPress.org API
 - Warns about unstable versions when installed version > WP.org's stable tag for the plugin
 
@@ -28,7 +28,6 @@ on:
   pull_request:
     paths:
       - 'composer.lock'
-      - 'composer.json'
 
 jobs:
   changelog:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Comment changelogs on PR

--- a/action.yml
+++ b/action.yml
@@ -84,30 +84,85 @@ runs:
             getComposerLock(pr.head.sha),
           ]);
 
-          // null = fetch/parse error; missing file (404) returns null without a warning
-          // Only proceed if we don't have warnings about failures
           if (fetchWarnings.length > 0) {
             console.log(`Warnings: ${fetchWarnings.join('; ')}`);
           }
 
-          const getPluginVersions = (lock) => {
-            const map = new Map();
-            if (!lock) return map;
-            for (const pkg of lock.packages || []) {
-              if (pkg.name?.startsWith('wp-plugin/')) {
-                map.set(pkg.name.replace('wp-plugin/', ''), pkg.version);
+          if (baseLock && headLock) {
+            // Full JSON comparison — accurate detection of all changed plugins
+            const getPluginVersions = (lock) => {
+              const map = new Map();
+              for (const pkg of lock.packages || []) {
+                if (pkg.name?.startsWith('wp-plugin/')) {
+                  map.set(pkg.name.replace('wp-plugin/', ''), pkg.version);
+                }
+              }
+              return map;
+            };
+
+            const baseVersions = getPluginVersions(baseLock);
+            const headVersions = getPluginVersions(headLock);
+
+            for (const [name, headVersion] of headVersions) {
+              const baseVersion = baseVersions.get(name);
+              if (baseVersion !== headVersion) {
+                pluginsMap.set(name, headVersion);
               }
             }
-            return map;
-          };
+          } else {
+            // Fallback: parse the diff patch (may miss plugins whose name line
+            // is unchanged context in the diff, but works without contents: read)
+            console.log('Falling back to diff-based detection');
+            fetchWarnings = [`Using diff-based detection (some updated plugins may not be listed). For full accuracy, add \`contents: read\` to your workflow permissions.`];
 
-          const baseVersions = getPluginVersions(baseLock);
-          const headVersions = getPluginVersions(headLock);
+            let page = 1;
+            const per_page = 100;
+            let composerLockPatch = null;
 
-          for (const [name, headVersion] of headVersions) {
-            const baseVersion = baseVersions.get(name);
-            if (baseVersion !== headVersion) {
-              pluginsMap.set(name, headVersion);
+            while (true) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page,
+                page,
+              });
+              if (!files.length) break;
+
+              for (const f of files) {
+                if (f.filename === 'composer.lock' && f.patch) {
+                  composerLockPatch = f.patch;
+                  const addedLines = f.patch.split('\n').filter(line => line.startsWith('+'));
+                  const addedContent = addedLines.join('\n');
+                  const matches = addedContent.match(/wp-plugin\/([a-z0-9\-]+)/gi) || [];
+                  matches.forEach(m => {
+                    const pluginName = m.toLowerCase().replace('wp-plugin/', '');
+                    pluginsMap.set(pluginName, null);
+                  });
+                }
+              }
+              if (files.length < per_page) break;
+              page += 1;
+            }
+
+            if (composerLockPatch) {
+              const lines = composerLockPatch.split('\n');
+              let currentPlugin = null;
+              for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+                if (line.includes('"name": "wp-plugin/')) {
+                  const match = line.match(/"wp-plugin\/([^"]+)"/);
+                  if (match) {
+                    currentPlugin = match[1];
+                  }
+                } else if (currentPlugin && line.includes('"version":')) {
+                  const versionMatch = line.match(/"version":\s*"([^"]+)"/);
+                  if (versionMatch && pluginsMap.has(currentPlugin)) {
+                    pluginsMap.set(currentPlugin, versionMatch[1]);
+                  }
+                  currentPlugin = null;
+                }
+              }
             }
           }
 

--- a/action.yml
+++ b/action.yml
@@ -33,67 +33,87 @@ runs:
           const MARKER = '<!-- wp-packages-changelog-bot -->';
           let pluginsMap = new Map();
 
-          let page = 1;
-          const per_page = 100;
-          let composerLockContent = null;
+          // Get the PR to find base and head refs
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+          });
 
-          while (true) {
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page,
-              page,
-            });
-            if (!files.length) break;
+          let fetchWarnings = [];
 
-            for (const f of files) {
-              if (f.filename === 'composer.lock' && f.patch) {
-                composerLockContent = f.patch;
-                const addedLines = f.patch.split('\n').filter(line => line.startsWith('+'));
-                const addedContent = addedLines.join('\n');
-                const matches = addedContent.match(/wp-plugin\/([a-z0-9\-]+)/gi) || [];
-                matches.forEach(m => {
-                  const pluginName = m.toLowerCase().replace('wp-plugin/', '');
-                  pluginsMap.set(pluginName, null);
-                });
-              } else if (f.filename === 'composer.json' && f.patch) {
-                const addedLines = f.patch.split('\n').filter(line => line.startsWith('+'));
-                const addedContent = addedLines.join('\n');
-                const matches = addedContent.match(/wp-plugin\/([a-z0-9\-]+)/gi) || [];
-                matches.forEach(m => {
-                  const pluginName = m.toLowerCase().replace('wp-plugin/', '');
-                  pluginsMap.set(pluginName, null);
-                });
+          async function getComposerLock(ref) {
+            try {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'composer.lock',
+                ref,
+              });
+
+              if (data.type !== 'file') {
+                fetchWarnings.push(`composer.lock at \`${ref.substring(0, 7)}\` is not a file (type: ${data.type})`);
+                return null;
               }
+
+              // For large files, content may be empty — fall back to the blob API
+              if (!data.content && data.sha) {
+                const { data: blob } = await github.rest.git.getBlob({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  file_sha: data.sha,
+                });
+                return JSON.parse(Buffer.from(blob.content, 'base64').toString('utf8'));
+              }
+
+              if (!data.content) {
+                fetchWarnings.push(`composer.lock at \`${ref.substring(0, 7)}\` has no content`);
+                return null;
+              }
+
+              return JSON.parse(Buffer.from(data.content, 'base64').toString('utf8'));
+            } catch (e) {
+              if (e.status === 404) return null;
+              fetchWarnings.push(`Failed to read composer.lock at \`${ref.substring(0, 7)}\`: ${e.message}`);
+              return null;
             }
-            if (files.length < per_page) break;
-            page += 1;
           }
 
-          if (composerLockContent) {
-            const lines = composerLockContent.split('\n');
-            let currentPlugin = null;
-            for (let i = 0; i < lines.length; i++) {
-              const line = lines[i];
-              if (line.includes('"name": "wp-plugin/')) {
-                const match = line.match(/"wp-plugin\/([^"]+)"/);
-                if (match) {
-                  currentPlugin = match[1];
-                }
-              } else if (currentPlugin && line.includes('"version":')) {
-                const versionMatch = line.match(/"version":\s*"([^"]+)"/);
-                if (versionMatch && pluginsMap.has(currentPlugin)) {
-                  pluginsMap.set(currentPlugin, versionMatch[1]);
-                }
-                currentPlugin = null;
+          const [baseLock, headLock] = await Promise.all([
+            getComposerLock(pr.base.sha),
+            getComposerLock(pr.head.sha),
+          ]);
+
+          // null = fetch/parse error; missing file (404) returns null without a warning
+          // Only proceed if we don't have warnings about failures
+          if (fetchWarnings.length > 0) {
+            console.log(`Warnings: ${fetchWarnings.join('; ')}`);
+          }
+
+          const getPluginVersions = (lock) => {
+            const map = new Map();
+            if (!lock) return map;
+            for (const pkg of lock.packages || []) {
+              if (pkg.name?.startsWith('wp-plugin/')) {
+                map.set(pkg.name.replace('wp-plugin/', ''), pkg.version);
               }
+            }
+            return map;
+          };
+
+          const baseVersions = getPluginVersions(baseLock);
+          const headVersions = getPluginVersions(headLock);
+
+          for (const [name, headVersion] of headVersions) {
+            const baseVersion = baseVersions.get(name);
+            if (baseVersion !== headVersion) {
+              pluginsMap.set(name, headVersion);
             }
           }
 
           const plugins = [...pluginsMap.keys()].sort();
 
-          if (plugins.length === 0) {
+          if (plugins.length === 0 && fetchWarnings.length === 0) {
             console.log('No WP Packages plugins changed');
             return;
           }
@@ -108,6 +128,10 @@ runs:
           const botComment = comments.data.find(c => c.body?.includes(MARKER));
 
           let comment = `${MARKER}\n# 🔌 WordPress Plugin Changelogs\n\n`;
+
+          if (fetchWarnings.length > 0) {
+            comment += `> **Warning:** ${fetchWarnings.join('; ')}\n>\n> Plugin changelog results may be incomplete.\n\n`;
+          }
           let totalLength = 0;
           const maxCommentLength = parseInt(process.env.MAX_COMMENT_LENGTH);
           const maxChangelogLength = parseInt(process.env.MAX_CHANGELOG_LENGTH);


### PR DESCRIPTION
## Summary

- Fix bug where only plugins whose `"name"` line appeared in an added diff hunk were detected — most version bumps were silently missed
- Replace fragile diff-patch parsing with full `composer.lock` JSON comparison between base and head commits
- Add blob API fallback for lockfiles >1MB where `getContent` returns empty content
- Surface fetch/parse warnings in the PR comment instead of silently degrading
- Fall back to diff-based detection when `contents: read` permission is unavailable, with a visible warning in the PR comment
- Update README and example workflow

> [!IMPORTANT]
> For full detection accuracy, add `contents: read` to your workflow permissions:
> ```diff
>     permissions:
> +     contents: read
>       pull-requests: write
> ```
> Without this, the action falls back to diff-based detection which may miss some plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)