### PR TITLE
Upgrade actions/github-script from v7 to v9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   using: 'composite'
   steps:
     - name: Comment changelogs on PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         MAX_CHANGELOG_LENGTH: ${{ inputs.max-changelog-length }}
         MAX_COMMENT_LENGTH: ${{ inputs.max-comment-length }}


### PR DESCRIPTION
Fixes #6

Upgrades `actions/github-script` from `v7` (Node.js 20) to `v9` (Node.js 24) to resolve the deprecation warning.

## Breaking changes in v9 — not applicable here
- `require('@actions/github')` no longer works — this script doesn't use `require()`
- `getOctokit` is now an injected parameter — this script doesn't declare its own `getOctokit`

The script only uses the standard injected `github`/`context` objects and global Node.js APIs (`fetch`, `Buffer`, `AbortController`), none of which are affected.

## Testing
Verified by temporarily pointing a consumer repo to this branch — action ran successfully with no Node.js deprecation warnings.